### PR TITLE
Use Wildcard Notation for Play Framework's API Documentation Version

### DIFF
--- a/src/main/scala/com/thoughtworks/sbtApiMappings/ApiMappings.scala
+++ b/src/main/scala/com/thoughtworks/sbtApiMappings/ApiMappings.scala
@@ -50,7 +50,8 @@ object ApiMappings extends AutoPlugin {
             Some(url(raw"""http://scala-lang.org/files/archive/api/$v/index.html"""))
           }
           case PlayRegex(_, _, version) => {
-            Some(url(raw"""https://playframework.com/documentation/$version/api/scala/index.html"""))
+            val wildcardVersion = version.replaceAll("[\\d]$", "x")
+            Some(url(raw"""https://playframework.com/documentation/$wildcardVersion/api/scala/index.html"""))
           }
           case IvyRegex(organization, name, jarBaseFile) if jarBaseFile.startsWith(s"$name-") => {
             val version = jarBaseFile.substring(name.length + 1, jarBaseFile.length)


### PR DESCRIPTION
Exact versions aren't always published. These URLs:

- `https://playframework.com/documentation/2.4.4/api/scala/index.html`
- `https://playframework.com/documentation/2.4.6/api/scala/index.html`
- `https://playframework.com/documentation/2.4.x/api/scala/index.html`

Are good, broken, and good respectively.