### PR TITLE
Fix url for JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ language: scala
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - openjdk11
 
 before_cache:
   - find $HOME/.sbt -name '*.lock' -delete

--- a/src/main/scala/com/thoughtworks/sbtApiMappings/BootstrapApiMappings.scala
+++ b/src/main/scala/com/thoughtworks/sbtApiMappings/BootstrapApiMappings.scala
@@ -27,10 +27,13 @@ object BootstrapApiMappings extends AutoPlugin {
     val javaVersion = sys.props("java.specification.version") match {
       case VersionNumber(Seq(1, javaVersion, _*), _, _) => javaVersion // 1.6-1.8
       case VersionNumber(Seq(javaVersion, _*),    _, _) => javaVersion // 9+
-      case specificationVersion =>
-        specificationVersion
+      case _ =>                                            8
     }
-    url(s"https://docs.oracle.com/javase/${javaVersion}/docs/api/index.html")
+    if (javaVersion >= 11) {
+      url(s"https://docs.oracle.com/en/java/javase/${javaVersion}/docs/api/index.html")
+    } else {
+      url(s"https://docs.oracle.com/javase/${javaVersion}/docs/api/index.html")
+    }
   }
 
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
@@ -46,7 +49,7 @@ object BootstrapApiMappings extends AutoPlugin {
             val log = streams.value.log
 
             if (!ManagementFactory.getRuntimeMXBean.isBootClassPathSupported) {
-              // Copied from scala-js/project/Build.scala for Java 9
+              // Copied from scala-js/project/Build.scala for Java 9 or later
               Map(file("/modules/java.base") -> bootstrapJavadocURL.value)
             } else {
               ManagementFactory.getRuntimeMXBean.getBootClassPath

--- a/src/sbt-test/sbt-api-mappings/jdk/build.sbt
+++ b/src/sbt-test/sbt-api-mappings/jdk/build.sbt
@@ -6,8 +6,8 @@ def regexMatches(matcher: scala.util.matching.Regex)(str: String): Boolean = {
 
 def javaVersion = VersionNumber(sys.props("java.specification.version"))
 
-def isJava9 = javaVersion match {
-  case VersionNumber(Seq(9, _*), _, _) => true
+def isJava(x: Integer) = javaVersion match {
+  case VersionNumber(Seq(y, _*), _, _) => x == y
   case _                               => false
 }
 
@@ -17,7 +17,7 @@ check := {
 
   val compileApiMappings = (apiMappings in Compile in doc).value
 
-  val expect = "https://docs.oracle.com/javase/\\d/docs/api/index.html".r
+  val expect = "https://docs.oracle.com/(?:en/java/)?javase/\\d+/docs/api/index.html".r
 
   val found = compileApiMappings.values.exists { url =>
     regexMatches(expect)(url.toString)

--- a/src/sbt-test/sbt-api-mappings/jdk/test
+++ b/src/sbt-test/sbt-api-mappings/jdk/test
@@ -4,4 +4,4 @@
 > doc
 $ exists target/api/index.html
 $ exists target/api/A.html
-> jgrep "https://docs.oracle.com/javase/\d+/docs/api/java/lang/Throwable.html" "target/api/A.html"
+> jgrep "https://docs.oracle.com/(?:en/java/)?javase/\d+/docs/api/java/lang/Throwable.html" "target/api/A.html"


### PR DESCRIPTION
The new base url is: https://docs.oracle.com/en/java/javase/11/docs/api/index.html