### PR TITLE
Scala 2.13.0-RC1 broken in JDK11

### DIFF
--- a/src/sbt-test/sbt-api-mappings/jdk/build.sbt
+++ b/src/sbt-test/sbt-api-mappings/jdk/build.sbt
@@ -6,7 +6,7 @@ def regexMatches(matcher: scala.util.matching.Regex)(str: String): Boolean = {
 
 scalaVersion in Global := "2.12.10"
 
-crossScalaVersions := Seq("2.12.10", "2.13.0-M5") // Broken in 2.13.0-RC1
+crossScalaVersions := Seq("2.12.10", "2.13.0-RC1") // Broken in 2.13.0-pre-c742cff
 
 def javaVersion = VersionNumber(sys.props("java.specification.version"))
 


### PR DESCRIPTION
Not broken-broken, but links don't work.