### PR TITLE
Give priority to existing `apiMappings` setting value

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,0 @@
-image: igeolise/scalajs-test-runner:latest
-vscode:
-  extensions:
-    - scala-lang.scala@0.3.8:wQBBM+lKILHBqOqlqW60xA==
-    - scalameta.metals@1.9.0:EyAIfy0ykjUn9htpw3f7GA==

--- a/src/main/scala/com/thoughtworks/sbtApiMappings/ApiMappings.scala
+++ b/src/main/scala/com/thoughtworks/sbtApiMappings/ApiMappings.scala
@@ -45,13 +45,13 @@ object ApiMappings extends AutoPlugin {
       inTask(doc) {
         Seq(
           autoAPIMappings := true,
-          apiMappings ++= {
+          apiMappings := {
             val rules = apiMappingRules.value
             dependencyClasspath.value.collect {
               case jar @ rules.extract(url)
                   if !apiMappings.value.exists(_._1 == jar.data) =>
                 jar.data -> url
-            }(collection.breakOut(Map.canBuildFrom))
+            }(collection.breakOut(Map.canBuildFrom)) ++ apiMappings.value
           }
         )
       }


### PR DESCRIPTION
This ensures that the `apiMappings` generated by the plugin are used only as a fallback.

Thanks for your consideration!